### PR TITLE
do not add excat duplicate hrefs

### DIFF
--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -88,6 +88,7 @@ module HtmlToPlainText
             if href &&
                 href =~ ABSOLUTE_URL_PATTERN &&
                 node.text =~ NOT_WHITESPACE_PATTERN &&
+                node.text != href &&
                 node.text != href[NON_PROTOCOL_PATTERN, 1] # use only text for <a href="mailto:a@b.com">a@b.com</a>
               out << " (#{href}) "
             end

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -100,7 +100,12 @@ RSpec.describe HtmlToPlainText do
       expect(text(html)).to eq "full (http://example.com/test)"
     end
 
-    it "only uses the name for duplicates" do
+    it "only uses the name for exact duplicates" do
+      html = "<a href='http://example.com'>http://example.com</a>"
+      expect(text(html)).to eq "http://example.com"
+    end
+
+    it "only uses the name for close duplicates" do
       html = "<a href='http://example.com'>example.com</a>"
       expect(text(html)).to eq "example.com"
     end


### PR DESCRIPTION
@bdurand forgot the obvious case while working on the special case ...

`http://example.com (http://example.com)` will now be `http://example.com`
