### PR TITLE
do not use pipes for layout tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'http://rubygems.org'
 
 gemspec
+
+gem 'byebug', :platform => (RUBY_VERSION > "2.0.0" ? :mri : :mswin)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     bump (0.5.2)
+    byebug (8.2.1)
     diff-lcs (1.2.5)
     mini_portile (0.6.2)
     nokogiri (1.6.6.2)
@@ -32,6 +33,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  byebug
   html_to_plain_text!
   rake
   rspec (> 2.6.0)

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -17,6 +17,7 @@ module HtmlToPlainText
   UL = "ul".freeze
   LI = "li".freeze
   A = "a".freeze
+  TABLE = "table".freeze
   NUMBERS = ["1", "a"].freeze
   ABSOLUTE_URL_PATTERN = /^[a-z]+:\/\/[a-z0-9]/i.freeze
   HTML_PATTERN = /[<&]/.freeze
@@ -30,6 +31,7 @@ module HtmlToPlainText
   EMPTY = "".freeze
   NEWLINE = "\n".freeze
   HREF = "href".freeze
+  TABLE_SEPARATOR = " | ".freeze
 
   # Helper instance method for converting HTML into plain text. This method simply calls HtmlToPlainText.plain_text.
   def plain_text(html)
@@ -59,7 +61,7 @@ module HtmlToPlainText
       end
 
       format_list_item(out, options) if parent.name == LI
-      out << "| " if parent.name == TR
+      out << "| " if parent.name == TR && data_table?(parent.parent)
 
       parent.children.each do |node|
         if node.text? || node.cdata?
@@ -82,7 +84,7 @@ module HtmlToPlainText
             out << NEWLINE unless out.end_with?(NEWLINE)
             out << "-------------------------------\n"
           elsif node.name == TD || node.name == TH
-            out << " | "
+            out << (data_table?(parent.parent) ? TABLE_SEPARATOR : SPACE)
           elsif node.name == A
             href = node[HREF]
             if href &&
@@ -146,6 +148,10 @@ module HtmlToPlainText
         options[:number] = number.next
         out << "#{number}. "
       end
+    end
+
+    def data_table?(table)
+      table.attributes['border'].to_s.to_i > 0
     end
   end
 end

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -61,9 +61,16 @@ RSpec.describe HtmlToPlainText do
     expect(text(html)).to eq "List\n\n1. one\n2. two\n\na. a\nb. b\n\n3. three"
   end
 
-  it "formats a table" do
-    html = "Table<table><tr><th>Col 1</th><th>Col 2</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>"
-    expect(text(html)).to eq "Table\n\n| Col 1 | Col 2 |\n| 1 | 2 |\n| 3 | 4 |"
+  describe "tables" do
+    it "formats a simgple table" do
+      html = "Table<table border='1'><tr><th>Col 1</th><th>Col 2</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>"
+      expect(text(html)).to eq "Table\n\n| Col 1 | Col 2 |\n| 1 | 2 |\n| 3 | 4 |"
+    end
+
+    it "does not add bars to a layout table" do
+      html = "Table<table border='0'><tr><th>Col 1</th><th>Col 2</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>"
+      expect(text(html)).to eq "Table\n\nCol 1 Col 2\n1 2\n3 4"
+    end
   end
 
   it "ignores inline tags without bodies" do
@@ -119,7 +126,6 @@ RSpec.describe HtmlToPlainText do
       expect(text("<a href='http://example.com/test2'> <img src='test'> </a>")).to eq ""
     end
   end
-
 
   it "unescapes entities" do
     html = "This &amp; th&#97;t"


### PR DESCRIPTION
lots of emails use tables for layouting and these pipes make the generated text hard to read

@bdurand 

atm we get:

```
|  |

|  |  |  |  |  |  |  |  |  |  |
|

| #tags

 |  |  |
|

| #requester

 |  |  |  |  |
|  |

| Please check the following purchase order..  |

 |  |  |  |  |  |  |  |  |  |
|  |  |

| Order GRS  |
```

with this patch we get:

```
#tags 

#requester 

Please check the following purchase order..

Order GRSS
```
