### PR TITLE
Handle exact duplicate link padded with whitespace

### DIFF
--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -91,6 +91,7 @@ module HtmlToPlainText
                 href =~ ABSOLUTE_URL_PATTERN &&
                 node.text =~ NOT_WHITESPACE_PATTERN &&
                 node.text != href &&
+                node.text.strip != href &&
                 node.text != href[NON_PROTOCOL_PATTERN, 1] # use only text for <a href="mailto:a@b.com">a@b.com</a>
               out << " (#{href}) "
             end

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe HtmlToPlainText do
       expect(text(html)).to eq "http://example.com"
     end
 
+    it "only uses the name for exact duplicates with whitespace" do
+      html = <<-HTML
+      <a href='http://example.com'>
+        http://example.com
+      </a>
+      HTML
+      expect(text(html)).to eq "http://example.com"
+    end
+
     it "only uses the name for close duplicates" do
       html = "<a href='http://example.com'>example.com</a>"
       expect(text(html)).to eq "example.com"


### PR DESCRIPTION
These previously were mapped as if the text were different from the href