### PR TITLE
various improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,26 +7,26 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    bump (0.5.2)
-    byebug (8.2.1)
-    diff-lcs (1.2.5)
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    rake (0.9.2)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    bump (0.7.0)
+    byebug (10.0.2)
+    diff-lcs (1.3)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
 
 PLATFORMS
   ruby
@@ -39,4 +39,4 @@ DEPENDENCIES
   rspec (> 2.6.0)
 
 BUNDLED WITH
-   1.10.6
+   1.17.2

--- a/html_to_plain_text.gemspec
+++ b/html_to_plain_text.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
 
   s.files = ['README.rdoc', 'VERSION', 'Rakefile', 'MIT_LICENSE'] +  Dir.glob('lib/**/*')
 
-  s.has_rdoc = true
   s.rdoc_options = ["--charset=UTF-8", "--main", "README.rdoc"]
   s.extra_rdoc_files = ["README.rdoc"]
 

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -21,12 +21,13 @@ module HtmlToPlainText
   NUMBERS = ["1", "a"].freeze
   ABSOLUTE_URL_PATTERN = /^[a-z]+:\/\/[a-z0-9]/i.freeze
   HTML_PATTERN = /[<&]/.freeze
-  TRAILING_WHITESPACE = /[ \t]+$/.freeze
+  TRAILING_WHITESPACE = /[[:blank:]]+$/.freeze
   BODY_TAG_XPATH = "/html/body".freeze
   CARRIAGE_RETURN_PATTERN = /\r\n?/.freeze
   LINE_BREAK_PATTERN = /[\n\r]/.freeze
   NON_PROTOCOL_PATTERN = /:\/?\/?(.*)/.freeze
-  NOT_WHITESPACE_PATTERN = /\S/.freeze
+  ALL_WHITESPACE_PATTERN = /[[:space:]]+/.freeze
+  NOT_WHITESPACE_PATTERN = /[^[:space:]]/.freeze
   SPACE = " ".freeze
   EMPTY = "".freeze
   NEWLINE = "\n".freeze
@@ -68,7 +69,7 @@ module HtmlToPlainText
         if node.text? || node.cdata?
           text = node.text
           unless options[:pre]
-            text = node.text.gsub(LINE_BREAK_PATTERN, SPACE).squeeze(SPACE)
+            text.gsub!(ALL_WHITESPACE_PATTERN, SPACE)
             text.lstrip! if WHITESPACE.include?(out[-1, 1])
           end
           out << text
@@ -89,7 +90,9 @@ module HtmlToPlainText
           elsif node.name == A && options[:show_links]
             href = node[HREF]
             if href && href =~ ABSOLUTE_URL_PATTERN
-              text = node.text.strip
+              text = node.text
+              text.gsub!(ALL_WHITESPACE_PATTERN, SPACE)
+              text.strip!
               if text.size > 0 &&
                    text != href &&
                    text != href[NON_PROTOCOL_PATTERN, 1] # use only text for <a href="mailto:a@b.com">a@b.com</a>

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -23,7 +23,7 @@ module HtmlToPlainText
   HTML_PATTERN = /[<&]/.freeze
   TRAILING_WHITESPACE = /[ \t]+$/.freeze
   BODY_TAG_XPATH = "/html/body".freeze
-  CARRIDGE_RETURN_PATTERN = /\r(\n?)/.freeze
+  CARRIAGE_RETURN_PATTERN = /\r(\n?)/.freeze
   LINE_BREAK_PATTERN = /[\n\r]/.freeze
   NON_PROTOCOL_PATTERN = /:\/?\/?(.*)/.freeze
   NOT_WHITESPACE_PATTERN = /\S/.freeze
@@ -46,7 +46,7 @@ module HtmlToPlainText
       return html.dup unless html =~ HTML_PATTERN
       body = Nokogiri::HTML::Document.parse(html).xpath(BODY_TAG_XPATH).first
       return unless body
-      convert_node_to_plain_text(body).strip.gsub(CARRIDGE_RETURN_PATTERN, NEWLINE)
+      convert_node_to_plain_text(body).strip.gsub(CARRIAGE_RETURN_PATTERN, NEWLINE)
     end
 
     private

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -2,7 +2,7 @@ require 'nokogiri'
 
 # The main method on this module +plain_text+ will convert a string of HTML to a plain text approximation.
 module HtmlToPlainText
-  IGNORE_TAGS = %w(script style object applet iframe).inject({}){|h, t| h[t] = true; h}.freeze
+  IGNORE_TAGS = %w(script noscript style object applet iframe).inject({}){|h, t| h[t] = true; h}.freeze
   PARAGRAPH_TAGS = %w(p h1 h2 h3 h4 h5 h6 table ol ul dl dd blockquote dialog figure aside section).inject({}){|h, t| h[t] = true; h}.freeze
   BLOCK_TAGS = %w(div address li dt center del article header header footer nav pre legend tr).inject({}){|h, t| h[t] = true; h}.freeze
   WHITESPACE = [" ", "\n", "\r"].freeze

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -23,7 +23,7 @@ module HtmlToPlainText
   HTML_PATTERN = /[<&]/.freeze
   TRAILING_WHITESPACE = /[ \t]+$/.freeze
   BODY_TAG_XPATH = "/html/body".freeze
-  CARRIAGE_RETURN_PATTERN = /\r(\n?)/.freeze
+  CARRIAGE_RETURN_PATTERN = /\r\n?/.freeze
   LINE_BREAK_PATTERN = /[\n\r]/.freeze
   NON_PROTOCOL_PATTERN = /:\/?\/?(.*)/.freeze
   NOT_WHITESPACE_PATTERN = /\S/.freeze
@@ -87,12 +87,13 @@ module HtmlToPlainText
             out << (data_table?(parent.parent) ? TABLE_SEPARATOR : SPACE)
           elsif node.name == A
             href = node[HREF]
-            if href &&
-                href =~ ABSOLUTE_URL_PATTERN &&
-                node.text =~ NOT_WHITESPACE_PATTERN &&
-                node.text != href &&
-                node.text != href[NON_PROTOCOL_PATTERN, 1] # use only text for <a href="mailto:a@b.com">a@b.com</a>
-              out << " (#{href}) "
+            if href && href =~ ABSOLUTE_URL_PATTERN
+              text = node.text.strip
+              if text.size > 0 &&
+                   text != href &&
+                   text != href[NON_PROTOCOL_PATTERN, 1] # use only text for <a href="mailto:a@b.com">a@b.com</a>
+                out << " (#{href}) "
+              end
             end
           elsif PARAGRAPH_TAGS.include?(node.name)
             append_paragraph_breaks(out)


### PR DESCRIPTION
Introduces the following changes:

* ignores `noscript` tags in html

* treats unicode `\u00a0` and similar as whitespace when considering space characters for various operations

* ignores whitespace when avoiding duplicate urls in the output

* adds a `:show_links` option to suppress outputting links (default behavior remains unchanged)

I will add tests if these changes seem acceptable.