### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/html_to_plain_text.gemspec
+++ b/html_to_plain_text.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ['Brian Durand']
   s.email = ['bdurand@embellishedvisions.com']
   s.homepage = "https://github.com/bdurand/html_to_plain_text"
+  s.license = "MIT"
 
   s.files = ['README.rdoc', 'VERSION', 'Rakefile', 'MIT_LICENSE'] +  Dir.glob('lib/**/*')
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.