### PR TITLE
Support frozen string literals

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,11 +10,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-env:
-  BUNDLE_CLEAN: "true"
-  BUNDLE_PATH: vendor/bundle
-  BUNDLE_JOBS: 3
-  BUNDLE_RETRY: 3
 jobs:
   specs:
     name: Run specs
@@ -22,21 +17,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - ruby: "ruby"
+        ruby:
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
+          bundler-cache: true
           ruby-version: "${{ matrix.ruby }}"
-      - name: Install bundler
-        run: |
-          bundle install --jobs 3 --retry 3
       - name: Run specs
         run: |
-          bundle exec rake spec
-      - name: Run standardrb
-        if:   matrix.standardrb == true
-        run:  bundle exec rake standard
+          bundle exec rake test

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - master
   workflow_dispatch:
+env:
+  RUBYOPT: '--enable=frozen-string-literal --debug=frozen-string-literal'
 jobs:
   specs:
     name: Run specs

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'

--- a/html_to_plain_text.gemspec
+++ b/html_to_plain_text.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name = 'html_to_plain_text'
   s.version = File.read(File.expand_path("../VERSION", __FILE__)).strip

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -56,6 +56,7 @@ module HtmlToPlainText
     # Convert an HTML node to plain text. This method is called recursively with the output and
     # formatting options for special tags.
     def convert_node_to_plain_text(parent, out = '', options = {})
+      out = out.dup if out.frozen?
       if PARAGRAPH_TAGS.include?(parent.name)
         append_paragraph_breaks(out)
       elsif BLOCK_TAGS.include?(parent.name)

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 
 # The main method on this module +plain_text+ will convert a string of HTML to a plain text approximation.
@@ -6,18 +8,18 @@ module HtmlToPlainText
   PARAGRAPH_TAGS = %w(p h1 h2 h3 h4 h5 h6 table ol ul dl dd blockquote dialog figure aside section).inject({}){|h, t| h[t] = true; h}.freeze
   BLOCK_TAGS = %w(div address li dt center del article header header footer nav pre legend tr).inject({}){|h, t| h[t] = true; h}.freeze
   WHITESPACE = [" ", "\n", "\r"].freeze
-  PLAINTEXT = "plaintext".freeze
-  PRE = "pre".freeze
-  BR = "br".freeze
-  HR = "hr".freeze
-  TD = "td".freeze
-  TH = "th".freeze
-  TR = "tr".freeze
-  OL = "ol".freeze
-  UL = "ul".freeze
-  LI = "li".freeze
-  A = "a".freeze
-  TABLE = "table".freeze
+  PLAINTEXT = "plaintext"
+  PRE = "pre"
+  BR = "br"
+  HR = "hr"
+  TD = "td"
+  TH = "th"
+  TR = "tr"
+  OL = "ol"
+  UL = "ul"
+  LI = "li"
+  A = "a"
+  TABLE = "table"
   NUMBERS = ["1", "a"].freeze
   ABSOLUTE_URL_PATTERN = /^[a-z]+:\/\/[a-z0-9]/i.freeze
   HTML_PATTERN = /[<&]/.freeze
@@ -27,11 +29,11 @@ module HtmlToPlainText
   LINE_BREAK_PATTERN = /[\n\r]/.freeze
   NON_PROTOCOL_PATTERN = /:\/?\/?(.*)/.freeze
   NOT_WHITESPACE_PATTERN = /\S/.freeze
-  SPACE = " ".freeze
-  EMPTY = "".freeze
-  NEWLINE = "\n".freeze
-  HREF = "href".freeze
-  TABLE_SEPARATOR = " | ".freeze
+  SPACE = " "
+  EMPTY = ""
+  NEWLINE = "\n"
+  HREF = "href"
+  TABLE_SEPARATOR = " | "
 
   # Helper instance method for converting HTML into plain text. This method simply calls HtmlToPlainText.plain_text.
   def plain_text(html)

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe HtmlToPlainText do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../lib/html_to_plain_text.rb", __FILE__)


### PR DESCRIPTION
## What

Makes the gem work correctly when frozen string literals are enabled, and enforces this on CI.

## Changes

- Trim and modernize the CI config: drop manual bundler env vars in favor of `bundler-cache: true`, and run the suite against Ruby 3.2, 3.3, 3.4, and 4.0.
- Add `# frozen_string_literal: true` magic comments across the codebase, set `RUBYOPT` to enable and debug frozen string literals on CI, and remove the now-redundant `.freeze` calls on string constants.
- Duplicate the accumulator string in `convert_node_to_plain_text` when it is frozen, so the default argument can be mutated safely.

## Testing

`bundle exec rake test` — 29 examples, 0 failures.