### PR TITLE
Optmization and bug fixes

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,4 +34,4 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
       - name: Run specs
         run: |
-          bundle exec rake test
+          bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,61 @@
-1.0.5
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+
+- Data tables with an explicit `tbody`, `thead`, or `tfoot` no longer lose their pipe separators.
+- Trailing spaces are no longer removed from inside `pre` tag content.
+- Fixed quadratic slowdown when converting large documents.
+- Multiline `href` values are rejected so `javascript:` URLs can no longer leak into the output.
+
+### Changed
+
+- `mailto:` and `tel:` link URLs are now included in the output when the link text differs from the address.
+- Return an empty string instead of `nil` when the parsed document has no body.
+- Line breaks are normalized and whitespace stripped on plain text input for consistency with HTML input.
+
+## 1.0.5
+
+### Changed
 
 Only add pipes on tables if border attributes set to non-zero value.
 
-1.0.4
+## 1.0.4
+
+### Changed
 
 Small tweak to outputing link URLs when they don't make sense.
 
-1.0.3
+## 1.0.3
 
-* improve performance slightly by replacing runtime strings with constants
-* testing on modern rubies (grosser)
-* using gemspec in Gemfile (grosser)
-* not shipping test files for smaller gem / faster installs / smaller cached gems (grosser)
-* rake bump:patch -> increment version (grosser)
-* rake release -> ship new version (grosser)
+### Changed
 
-1.0.2
+- improve performance slightly by replacing runtime strings with constants
+- testing on modern rubies (grosser)
+- using gemspec in Gemfile (grosser)
+- not shipping test files for smaller gem / faster installs / smaller cached gems (grosser)
+- rake bump:patch -> increment version (grosser)
+- rake release -> ship new version (grosser)
 
-* remove trailing whitespace on converted text.
+## 1.0.2
 
-1.0.1
+### Changed
 
-* better handling of non-html or nil text
+- remove trailing whitespace on converted text.
 
-1.0.0
+## 1.0.1
 
-* initial release
+### Changed
+
+- better handling of non-html or nil text
+
+## 1.0.0
+
+### Added
+
+- initial release

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,8 @@ end
 require "bundler/gem_tasks"
 
 task :verify_release_branch do
-  unless `git rev-parse --abbrev-ref HEAD`.chomp == "main"
-    warn "Gem can only be released from the main branch"
+  unless `git rev-parse --abbrev-ref HEAD`.chomp == "master"
+    warn "Gem can only be released from the master branch"
     exit 1
   end
 end

--- a/html_to_plain_text.gemspec
+++ b/html_to_plain_text.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage}/blob/main/CHANGELOG.md"
+    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGELOG.md"
   }
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -71,10 +71,13 @@ module HtmlToPlainText
     # formatting options for special tags.
     def convert_node_to_plain_text(parent, out, options = {})
       out = out.dup if out.frozen?
+      # The buffer tail here was written before this node opened, so it is only
+      # preformatted content when an ancestor (not this node itself) is a pre tag.
+      trim = !options[:pre] || parent.name == PRE
       if PARAGRAPH_TAGS.include?(parent.name)
-        append_paragraph_breaks(out)
+        append_paragraph_breaks(out, trim: trim)
       elsif BLOCK_TAGS.include?(parent.name)
-        append_block_breaks(out)
+        append_block_breaks(out, trim: trim)
       end
 
       format_list_item(out, options) if parent.name == LI
@@ -94,10 +97,10 @@ module HtmlToPlainText
           convert_node_to_plain_text(node, out, child_options(node, options))
 
           if node.name == BR
-            trim_trailing_blanks!(out)
+            trim_trailing_blanks!(out) unless options[:pre]
             out << NEWLINE
           elsif node.name == HR
-            trim_trailing_blanks!(out)
+            trim_trailing_blanks!(out) unless options[:pre]
             out << NEWLINE unless out.end_with?(NEWLINE)
             out << "-------------------------------\n"
           elsif node.name == TD || node.name == TH
@@ -115,9 +118,10 @@ module HtmlToPlainText
               end
             end
           elsif PARAGRAPH_TAGS.include?(node.name)
-            append_paragraph_breaks(out)
+            append_paragraph_breaks(out, trim: !options[:pre])
           elsif BLOCK_TAGS.include?(node.name)
-            append_block_breaks(out)
+            # A closing pre tag leaves preformatted content at the buffer tail.
+            append_block_breaks(out, trim: !options[:pre] && node.name != PRE)
           end
         end
       end
@@ -143,8 +147,8 @@ module HtmlToPlainText
 
     # Add double line breaks between paragraph elements. If line breaks already exist,
     # new ones will only be added to get to two.
-    def append_paragraph_breaks(out)
-      trim_trailing_blanks!(out)
+    def append_paragraph_breaks(out, trim: true)
+      trim_trailing_blanks!(out) if trim
       if out.end_with?(NEWLINE)
         out << NEWLINE unless out.end_with?("\n\n")
       else
@@ -154,8 +158,8 @@ module HtmlToPlainText
 
     # Add a single line break between block elements. If a line break already exists,
     # none will be added.
-    def append_block_breaks(out)
-      trim_trailing_blanks!(out)
+    def append_block_breaks(out, trim: true)
+      trim_trailing_blanks!(out) if trim
       out << NEWLINE unless out.end_with?(NEWLINE)
     end
 

--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -10,7 +10,7 @@ module HtmlToPlainText
   PARAGRAPH_TAGS = %w[p h1 h2 h3 h4 h5 h6 table ol ul dl dd blockquote dialog figure aside section].each_with_object({}) { |t, h|
     h[t] = true
   }.freeze
-  BLOCK_TAGS = %w[div address li dt center del article header header footer nav pre legend tr].each_with_object({}) { |t, h|
+  BLOCK_TAGS = %w[div address li dt center del article header footer nav pre legend tr].each_with_object({}) { |t, h|
     h[t] = true
   }.freeze
   WHITESPACE = [" ", "\n", "\r"].freeze
@@ -27,9 +27,8 @@ module HtmlToPlainText
   A = "a"
   TABLE = "table"
   NUMBERS = ["1", "a"].freeze
-  ABSOLUTE_URL_PATTERN = /^[a-z]+:\/\/[a-z0-9]/i
-  HTML_PATTERN = /[<&]/.freeze
-  TRAILING_WHITESPACE = /[[:blank:]]+$/
+  LINK_URL_PATTERN = /\A(?:[a-z][a-z0-9.+-]*:\/\/[a-z0-9]|mailto:|tel:)/i
+  HTML_PATTERN = /[<&]/
   BODY_TAG_XPATH = "/html/body"
   CARRIAGE_RETURN_PATTERN = /\r\n?/
   LINE_BREAK_PATTERN = /[\n\r]/
@@ -37,6 +36,7 @@ module HtmlToPlainText
   ALL_WHITESPACE_PATTERN = /[[:space:]]+/
   NOT_WHITESPACE_PATTERN = /[^[:space:]]/
   SPACE = " "
+  TAB = "\t"
   EMPTY = ""
   NEWLINE = "\n"
   HREF = "href"
@@ -59,9 +59,9 @@ module HtmlToPlainText
     # @return [String] The plain text approximation of the HTML.
     def plain_text(html, show_links: true)
       return nil if html.nil?
-      return html.dup unless HTML_PATTERN.match?(html)
+      return html.gsub(CARRIAGE_RETURN_PATTERN, NEWLINE).strip unless HTML_PATTERN.match?(html)
       body = Nokogiri::HTML::Document.parse(html).xpath(BODY_TAG_XPATH).first
-      return unless body
+      return +"" unless body
       convert_node_to_plain_text(body, "", show_links: show_links).strip.gsub(CARRIAGE_RETURN_PATTERN, NEWLINE)
     end
 
@@ -78,7 +78,7 @@ module HtmlToPlainText
       end
 
       format_list_item(out, options) if parent.name == LI
-      out << "| " if parent.name == TR && data_table?(parent.parent)
+      out << "| " if parent.name == TR && data_table?(parent)
 
       parent.children.each do |node|
         if node.text? || node.cdata?
@@ -94,17 +94,17 @@ module HtmlToPlainText
           convert_node_to_plain_text(node, out, child_options(node, options))
 
           if node.name == BR
-            out.sub!(TRAILING_WHITESPACE, EMPTY)
+            trim_trailing_blanks!(out)
             out << NEWLINE
           elsif node.name == HR
-            out.sub!(TRAILING_WHITESPACE, EMPTY)
+            trim_trailing_blanks!(out)
             out << NEWLINE unless out.end_with?(NEWLINE)
             out << "-------------------------------\n"
           elsif node.name == TD || node.name == TH
-            out << (data_table?(parent.parent) ? TABLE_SEPARATOR : SPACE)
+            out << (data_table?(parent) ? TABLE_SEPARATOR : SPACE)
           elsif node.name == A && options[:show_links]
             href = node[HREF]
-            if href && href =~ ABSOLUTE_URL_PATTERN
+            if href && href =~ LINK_URL_PATTERN
               text = node.text
               text.gsub!(ALL_WHITESPACE_PATTERN, SPACE)
               text.strip!
@@ -144,7 +144,7 @@ module HtmlToPlainText
     # Add double line breaks between paragraph elements. If line breaks already exist,
     # new ones will only be added to get to two.
     def append_paragraph_breaks(out)
-      out.sub!(TRAILING_WHITESPACE, EMPTY)
+      trim_trailing_blanks!(out)
       if out.end_with?(NEWLINE)
         out << NEWLINE unless out.end_with?("\n\n")
       else
@@ -155,8 +155,13 @@ module HtmlToPlainText
     # Add a single line break between block elements. If a line break already exists,
     # none will be added.
     def append_block_breaks(out)
-      out.sub!(TRAILING_WHITESPACE, EMPTY)
+      trim_trailing_blanks!(out)
       out << NEWLINE unless out.end_with?(NEWLINE)
+    end
+
+    # Remove spaces and tabs from the end of the output buffer.
+    def trim_trailing_blanks!(out)
+      out.slice!(-1) while out.end_with?(SPACE, TAB)
     end
 
     # Add an appropriate bullet or number to a list element.
@@ -170,7 +175,10 @@ module HtmlToPlainText
       end
     end
 
-    def data_table?(table)
+    def data_table?(tr)
+      table = tr.parent
+      table = table.parent while table && table.name != TABLE
+      return false unless table
       table.attributes["border"].to_s.to_i > 0
     end
   end

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe HtmlToPlainText do
     expect(text(html)).to eq "foo  \nbar\n\nafter"
   end
 
+  it "does not remove trailing blanks before a <br> tag inside <pre> tag blocks" do
+    html = "<pre>foo  <br>bar</pre>"
+    expect(text(html)).to eq "foo  \nbar"
+  end
+
+  it "does not remove trailing blanks from the last line of a <pre> tag block" do
+    html = "<pre>foo  </pre><div>bar</div>"
+    expect(text(html)).to eq "foo  \nbar"
+  end
+
   it "removes inline formatting tags" do
     html = "This is <strong>so</strong> cool. I<em> mean <em>it."
     expect(text(html)).to eq "This is so cool. I mean it."

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe HtmlToPlainText do
     expect(text(html)).to eq "This is a test\nwith\n  pre tags\nend"
   end
 
+  it "does not remove trailing blanks inside <pre> tag blocks" do
+    html = "<pre>foo  \nbar</pre><br>after"
+    expect(text(html)).to eq "foo  \nbar\n\nafter"
+  end
+
   it "removes inline formatting tags" do
     html = "This is <strong>so</strong> cool. I<em> mean <em>it."
     expect(text(html)).to eq "This is so cool. I mean it."
@@ -76,6 +81,16 @@ RSpec.describe HtmlToPlainText do
     it "does not add bars to a layout table" do
       html = "Table<table border='0'><tr><th>Col 1</th><th>Col 2</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>"
       expect(text(html)).to eq "Table\n\nCol 1 Col 2\n1 2\n3 4"
+    end
+
+    it "formats a table with an explicit tbody" do
+      html = "<table border='1'><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>"
+      expect(text(html)).to eq "| 1 | 2 |\n| 3 | 4 |"
+    end
+
+    it "formats a table with a thead and tbody" do
+      html = "<table border='1'><thead><tr><th>Col 1</th><th>Col 2</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+      expect(text(html)).to eq "| Col 1 | Col 2 |\n| 1 | 2 |"
     end
   end
 
@@ -128,6 +143,26 @@ RSpec.describe HtmlToPlainText do
       expect(text(html)).to eq "john@example.com"
     end
 
+    it "includes mailto URLs when the text is different" do
+      html = "<a href='mailto:john@example.com'>Contact John</a>"
+      expect(text(html)).to eq "Contact John (mailto:john@example.com)"
+    end
+
+    it "includes tel URLs when the text is different" do
+      html = "<a href='tel:+15555551234'>Call us</a>"
+      expect(text(html)).to eq "Call us (tel:+15555551234)"
+    end
+
+    it "only uses the name for tel duplicates" do
+      html = "<a href='tel:+15555551234'>+15555551234</a>"
+      expect(text(html)).to eq "+15555551234"
+    end
+
+    it "discards javascript and other non-link protocols" do
+      expect(text("<a href='javascript:alert(1)'>click</a>")).to eq "click"
+      expect(text("<a href=\"javascript:x\nhttp://y\">click</a>")).to eq "click"
+    end
+
     it "ignores empty" do
       expect(text("<a href='http://example.com/test2'> <img src='test'> </a>")).to eq ""
     end
@@ -158,6 +193,14 @@ RSpec.describe HtmlToPlainText do
 
   it "handles non-html text" do
     expect(text("test")).to eq "test"
+  end
+
+  it "normalizes line breaks in non-html text" do
+    expect(text("line1\r\nline2\rline3")).to eq "line1\nline2\nline3"
+  end
+
+  it "returns an empty string when there is no body" do
+    expect(text("<!-- just a comment -->")).to eq ""
   end
 
   it "handles UTF-8 characters" do


### PR DESCRIPTION
### Fixed

- Data tables with an explicit `tbody`, `thead`, or `tfoot` no longer lose their pipe separators.
- Trailing spaces are no longer removed from inside `pre` tag content.
- Fixed quadratic slowdown when converting large documents.
- Multiline `href` values are rejected so `javascript:` URLs can no longer leak into the output.

### Changed

- `mailto:` and `tel:` link URLs are now included in the output when the link text differs from the address.
- Return an empty string instead of `nil` when the parsed document has no body.
- Line breaks are normalized and whitespace stripped on plain text input for consistency with HTML input.
